### PR TITLE
Add LinkedIn profile links for founders in About section

### DIFF
--- a/index.html
+++ b/index.html
@@ -220,7 +220,7 @@
             <div class="founders-grid">
                 <div class="founder-card fade-up">
                     <div class="founder-image">                        
-                        <img src="https://media.licdn.com/dms/image/v2/C4E03AQEr66zFMlT0qw/profile-displayphoto-shrink_400_400/profile-displayphoto-shrink_400_400/0/1628470496740?e=1776902400&v=beta&t=nLQvKaLQ7G_a6Lu5PvQyG84H1fb7zeTuDB90efhZ2gw" alt="Founder 1" />
+                        <a href="https://www.linkedin.com/in/diogenesvazmelo/" target="_blank" rel="noopener noreferrer"><img src="https://media.licdn.com/dms/image/v2/C4E03AQEr66zFMlT0qw/profile-displayphoto-shrink_400_400/profile-displayphoto-shrink_400_400/0/1628470496740?e=1776902400&v=beta&t=nLQvKaLQ7G_a6Lu5PvQyG84H1fb7zeTuDB90efhZ2gw" alt="Founder 1" /></a>
                     </div>
                     <h3 class="founder-name">Diogenes Vaz de Melo</h3>
                     <p class="founder-role">Role & Expertise</p>
@@ -229,7 +229,7 @@
 
                 <div class="founder-card fade-up delay-100">
                     <div class="founder-image">
-                        <img src="https://media.licdn.com/dms/image/v2/D4D03AQGCPIv3rToESQ/profile-displayphoto-scale_400_400/B4DZsxufNYJYAk-/0/1766065830223?e=1776902400&v=beta&t=hmjp0TnK61gKajeEf9C-uiMr_NTBbNxcfPo4FIwDFYM" alt="Founder 2" />
+                        <a href="https://www.linkedin.com/in/fabriciohgalvaoliveira/" target="_blank" rel="noopener noreferrer"><img src="https://media.licdn.com/dms/image/v2/D4D03AQGCPIv3rToESQ/profile-displayphoto-scale_400_400/B4DZsxufNYJYAk-/0/1766065830223?e=1776902400&v=beta&t=hmjp0TnK61gKajeEf9C-uiMr_NTBbNxcfPo4FIwDFYM" alt="Founder 2" /></a>
                     </div>
                     <h3 class="founder-name">Fabricio Henrique Galvão de Oliveira</h3>
                     <p class="founder-role">Role & Expertise</p>
@@ -238,7 +238,7 @@
 
                 <div class="founder-card fade-up delay-200">
                     <div class="founder-image">
-                        <img src="https://media.licdn.com/dms/image/v2/D4D03AQGyia7iykc3BQ/profile-displayphoto-scale_400_400/B4DZ06KT8xJoAg-/0/1774797280054?e=1776902400&v=beta&t=w6zOIdc3UpjR8_qOqvz9yGDRCGgdfrcsE5aslTS9lYM" alt="Founder 3" />
+                        <a href="https://www.linkedin.com/in/vanessa-aparecida-valadares/" target="_blank" rel="noopener noreferrer"><img src="https://media.licdn.com/dms/image/v2/D4D03AQGyia7iykc3BQ/profile-displayphoto-scale_400_400/B4DZ06KT8xJoAg-/0/1774797280054?e=1776902400&v=beta&t=w6zOIdc3UpjR8_qOqvz9yGDRCGgdfrcsE5aslTS9lYM" alt="Founder 3" /></a>
                     </div>
                     <h3 class="founder-name">Vanessa Valadares</h3>
                     <p class="founder-role">Role & Expertise</p>


### PR DESCRIPTION
This pull request updates the founders section in `index.html` to make each founder's image a clickable link to their LinkedIn profile. This improves user experience by allowing visitors to easily access more information about each founder.

**Enhancements to Founders Section:**

* Made each founder's image a link to their respective LinkedIn profile, opening in a new tab and using `rel="noopener noreferrer"` for security. [[1]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L223-R223) [[2]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L232-R232) [[3]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L241-R241)