### PR TITLE
Fix form resubmit privacy leak

### DIFF
--- a/script.js
+++ b/script.js
@@ -213,21 +213,39 @@ function init() {
                 })
             })
                 .then(response => response.json())
-                .then(data => {
+                .then(_data => {
                     const modalBody = document.querySelector('.modal-content');
-                    const originalContent = modalBody.innerHTML;
-                    modalBody.innerHTML = `
-                    <div class="contact-success">
+
+                    // Hide existing children
+                    Array.from(modalBody.children).forEach(child => {
+                        if (!child.classList.contains('modal-close')) {
+                            child.style.display = 'none';
+                        }
+                    });
+
+                    // Create success message
+                    const successDiv = document.createElement('div');
+                    successDiv.className = 'contact-success';
+                    successDiv.id = 'contact-success-message';
+                    successDiv.innerHTML = `
                         <div class="contact-success-icon">
                             <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>
                         </div>
                         <h3 class="modal-title">Message Sent!</h3>
                         <p class="modal-desc" style="margin-bottom: 0;">Thank you for reaching out. We will get back to you soon.</p>
-                    </div>
-                `;
+                    `;
+                    modalBody.appendChild(successDiv);
+
                     setTimeout(() => {
                         closeContactModal();
-                        setTimeout(() => { modalBody.innerHTML = originalContent; }, 300);
+                        setTimeout(() => {
+                            // Remove success message and restore visibility
+                            const msg = document.getElementById('contact-success-message');
+                            if (msg) msg.remove();
+                            Array.from(modalBody.children).forEach(child => {
+                                child.style.display = '';
+                            });
+                        }, 300);
                     }, 4000);
                 })
                 .catch(error => {


### PR DESCRIPTION
Refactored the contact form submission logic to avoid replacing the `innerHTML` of the modal body when showing the success message. 

Replacing the `innerHTML` caused the DOM to be rebuilt, which detached the `submit` event listener on the form. This meant that if a user opened the modal again and submitted the form, `e.preventDefault()` would not run, and the form would submit via a default `GET` request, putting the user's potentially sensitive input into the URL query parameters. 

By hiding the original elements and creating/appending the success message dynamically, the form elements and their event listeners are preserved.

---
*PR created automatically by Jules for task [3999632825390681504](https://jules.google.com/task/3999632825390681504) started by @Fabriciodevbranch*